### PR TITLE
Use unified resume field in email submission

### DIFF
--- a/api/send-email.js
+++ b/api/send-email.js
@@ -73,18 +73,18 @@ export default async function handler(req, res) {
     delete formData.type;
     
     // We'll handle resume as a base64 string if it's included
-    let resumeData = null;
+    let resumeFile = null;
     // Define resumeAttachment at the function scope so it's available throughout
     let resumeAttachment = null;
-    if (body.resumeData) {
+    if (body.resume) {
       try {
-        resumeData = {
+        resumeFile = {
           filename: body.resumeFilename || 'resume.pdf',
-          content: Buffer.from(body.resumeData, 'base64')
+          content: Buffer.from(body.resume, 'base64')
         };
-        console.log(`Resume processed: ${body.resumeFilename}, ${Math.round(body.resumeData.length/1.37/1024)}KB`);
+        console.log(`Resume processed: ${body.resumeFilename}, ${Math.round(body.resume.length/1.37/1024)}KB`);
         // Remove these from formData to keep it clean
-        delete formData.resumeData;
+        delete formData.resume;
         delete formData.resumeFilename;
       } catch (error) {
         console.error('Error processing resume data:', error);
@@ -164,14 +164,14 @@ export default async function handler(req, res) {
       `;
       
       // Handle resume attachment if present
-      if (resumeData) {
+      if (resumeFile) {
         // We have resume data sent as base64
-        emailText += `\nResume: ${resumeData.filename} (attached)`;
-        emailHtml += `<p><strong>Resume:</strong> ${resumeData.filename} (attached)</p>`;
-        
+        emailText += `\nResume: ${resumeFile.filename} (attached)`;
+        emailHtml += `<p><strong>Resume:</strong> ${resumeFile.filename} (attached)</p>`;
+
         resumeAttachment = {
-          filename: resumeData.filename,
-          content: resumeData.content
+          filename: resumeFile.filename,
+          content: resumeFile.content
         };
       }
     } 

--- a/api/send-email.ts
+++ b/api/send-email.ts
@@ -54,7 +54,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     // Parse the request body
-    const { type, ...formData } = req.body;
+    const { type, resume, resumeFilename, ...formData } = req.body;
 
     // Basic validation
     if (!type) {
@@ -128,15 +128,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       `;
       
       // Handle resume attachment if present
-      if (req.body.resume) {
+      if (resume) {
         // For now, we just note that a resume was included
         // In a real implementation with Vercel, you would:
         // 1. Store the file in a storage service like AWS S3
         // 2. Include a link to the file in the email
-        
-        emailText += '\nResume was attached to the application.';
-        emailHtml += '<p><strong>Resume:</strong> Included in submission</p>';
-        
+
+        const filename = resumeFilename || 'Resume';
+        emailText += `\nResume: ${filename} (attached)`;
+        emailHtml += `<p><strong>Resume:</strong> ${filename} (attached)</p>`;
+
         // Note: To fully implement file upload handling, you would need:
         // 1. A storage service (AWS S3, Google Cloud Storage, etc.)
         // 2. Proper multipart form handling library

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -68,7 +68,7 @@ export async function submitForm(
         try {
           // Convert file to base64
           const base64data = await fileToBase64(resumeFile);
-          formDataObj.resumeData = base64data;
+          formDataObj.resume = base64data;
           formDataObj.resumeFilename = resumeFile.name;
           console.log(
             `Resume ${resumeFile.name} (${Math.round(resumeFile.size / 1024)}KB) converted to base64 successfully`


### PR DESCRIPTION
## Summary
- send resume as `resume` with separate filename in the email service
- read `resume` and `resumeFilename` in the email API and mention the file in messages
- update server JS handler to process new resume field and attachment

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4cb24c58832e8c6a53357b02e6c2